### PR TITLE
Adding search topics filter in Browse and Sync Topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.kafkamgt.uiapi</groupId>
     <artifactId>kafkawize</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
     <packaging>jar</packaging>
 
     <name>uiapi</name>

--- a/src/main/java/com/kafkamgt/uiapi/controller/TopicController.java
+++ b/src/main/java/com/kafkamgt/uiapi/controller/TopicController.java
@@ -26,6 +26,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 @RestController
@@ -254,7 +255,8 @@ public class TopicController {
     }
 
     @RequestMapping(value = "/getTopics", method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<List<TopicInfo>> getTopics(@RequestParam("env") String env, @RequestParam("pageNo") String pageNo) {
+    public ResponseEntity<List<TopicInfo>> getTopics(@RequestParam("env") String env, @RequestParam("pageNo") String pageNo,
+                                                     @RequestParam(value="topicnamesearch",required=false) String topicNameSearch) {
 
         LOG.info(pageNo+" In get topics " + env);
         String json = "{ \"name\": \"John\" }";
@@ -273,6 +275,9 @@ public class TopicController {
             List<TopicInfo> topicsList1 = new ArrayList();
             return new ResponseEntity<List<TopicInfo>>(topicsList1, HttpStatus.OK);
         }
+
+        if(topicNameSearch != null)
+            topicNameSearch = topicNameSearch.trim();
 
         Env envSelected= createTopicHelper.selectEnvDetails(env);
         String bootstrapHost=envSelected.getHost()+":"+envSelected.getPort();
@@ -294,6 +299,23 @@ public class TopicController {
 
         topicCounter = 0;
         List<String> topicsList = new ArrayList(s.getBody());
+
+        List<String> topicFilteredList = topicsList;
+        // Filter topics on topic name for search
+
+        if(topicNameSearch!=null && topicNameSearch.length()>0){
+            final String topicSearchFilter = topicNameSearch;
+            topicFilteredList = topicsList.stream().filter(topic-> {
+                if(topic.contains(topicSearchFilter))
+                    return true;
+                else
+                    return false;
+                }
+            ).collect(Collectors.toList());
+        }
+
+        topicsList = topicFilteredList;
+
         Collections.sort(topicsList);
 
         int totalRecs = topicsList.size();
@@ -303,7 +325,10 @@ public class TopicController {
 
         int requestPageNo = Integer.parseInt(pageNo);
 
-        List<TopicInfo> topicsListMap = new ArrayList<>();
+        List<TopicInfo> topicsListMap = null;//new ArrayList<>();
+        if(totalRecs>0)
+            topicsListMap = new ArrayList<>();
+
         int startVar = (requestPageNo-1) * recsPerPage;
         int lastVar = (requestPageNo) * (recsPerPage);
 
@@ -349,7 +374,8 @@ public class TopicController {
     }
 
     @RequestMapping(value = "/getSyncTopics", method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<List<TopicRequest>> getSyncTopics(@RequestParam("env") String env, @RequestParam("pageNo") String pageNo) {
+    public ResponseEntity<List<TopicRequest>> getSyncTopics(@RequestParam("env") String env, @RequestParam("pageNo") String pageNo,
+                        @RequestParam(value="topicnamesearch",required=false) String topicNameSearch) {
 
         LOG.info(pageNo+" In get sync topics " + env);
         String json = "{ \"name\": \"\" }";
@@ -369,6 +395,9 @@ public class TopicController {
             return new ResponseEntity<List<TopicRequest>>(topicsList1, HttpStatus.OK);
         }
 
+        if(topicNameSearch != null)
+            topicNameSearch = topicNameSearch.trim();
+
         Env envSelected= createTopicHelper.selectEnvDetails(env);
         String bootstrapHost=envSelected.getHost()+":"+envSelected.getPort();
 
@@ -386,6 +415,23 @@ public class TopicController {
 
         topicCounter = 0;
         List<String> topicsList = new ArrayList(s.getBody());
+
+        List<String> topicFilteredList = topicsList;
+        // Filter topics on topic name for search
+
+        if(topicNameSearch!=null && topicNameSearch.length()>0){
+            final String topicSearchFilter = topicNameSearch;
+            topicFilteredList = topicsList.stream().filter(topic-> {
+                        if(topic.contains(topicSearchFilter))
+                            return true;
+                        else
+                            return false;
+                    }
+            ).collect(Collectors.toList());
+        }
+
+        topicsList = topicFilteredList;
+
         Collections.sort(topicsList);
 
         int totalRecs = topicsList.size();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.port:9097
 
 # db.storetype should be "cassandra" or "rdbms"
-db.storetype=rdbms
+db.storetype=cassandra
 
 clusterapi.url:http://localhost:9343
 clusterapi.username:user1

--- a/src/main/resources/static/js/browseTopics.js
+++ b/src/main/resources/static/js/browseTopics.js
@@ -98,12 +98,15 @@ app.controller("browseTopicsCtrl", function($scope, $http, $location, $window) {
 			url: "/getTopics",
             headers : { 'Content-Type' : 'application/json' },
             params: {'env' : $scope.getTopics.envName.name,
-                'pageNo' : pageNoSelected }
+                'pageNo' : pageNoSelected,
+                 'topicnamesearch' : $scope.getTopics.topicnamesearch}
 		}).success(function(output) {
 			$scope.resultBrowse = output;
-			if(output!=null){
+			if(output!=null && output.length !=0){
                 $scope.resultPages = output[0].allPageNos;
                 $scope.resultPageSelected = pageNoSelected;
+            }else{
+                $scope.resultPages = null;
             }
 		}).error(
 			function(error) 

--- a/src/main/resources/static/js/synchronizeTopics.js
+++ b/src/main/resources/static/js/synchronizeTopics.js
@@ -96,7 +96,9 @@ app.controller("synchronizeTopicsCtrl", function($scope, $http, $location, $wind
                 method: "POST",
                 url: "/updateSyncTopics",
                 headers : { 'Content-Type' : 'application/json' },
-                params: {'updatedSyncTopics' : $scope.updatedSyncStr , 'envSelected': $scope.getTopics.envName.name},
+                params: {'updatedSyncTopics' : $scope.updatedSyncStr ,
+                         'envSelected': $scope.getTopics.envName.name
+                         },
                 data: {'updatedSyncTopics' : $scope.updatedSyncStr}
             }).success(function(output) {
                 $scope.alert = "Topic Sync Request : "+output.result;
@@ -126,11 +128,11 @@ app.controller("synchronizeTopicsCtrl", function($scope, $http, $location, $wind
 			method: "GET",
 			url: "/getSyncTopics",
             headers : { 'Content-Type' : 'application/json' },
-            params: {'env' : $scope.getTopics.envName.name,
+            params: {'env' : $scope.getTopics.envName.name, 'topicnamesearch' : $scope.getTopics.topicnamesearch,
                 'pageNo' : pageNoSelected }
 		}).success(function(output) {
 			$scope.resultBrowse = output;
-			if(output!=null){
+			if(output!=null && output.length !=0){
                 $scope.resultPages = output[0].allPageNos;
                 $scope.resultPageSelected = pageNoSelected;
             }

--- a/src/main/resources/templates/browseTopics.html
+++ b/src/main/resources/templates/browseTopics.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 
+<!--suppress ALL -->
 <html ng-app="browseTopicsApp" ng-controller="browseTopicsCtrl">
 
 <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
@@ -349,6 +350,15 @@
 										<td>
 											<select ng-model="getTopics.envName" ng-options="env as env.name for env in allenvs">
 											</select>
+										</td>
+									</tr>
+
+									<tr>
+										<td>
+											<font face=verdana size=2><b>Topic Name (filter)</b></font>
+										</td>
+										<td>
+											<input ng-model="getTopics.topicnamesearch">
 										</td>
 									</tr>
 

--- a/src/main/resources/templates/synchronizeTopics.html
+++ b/src/main/resources/templates/synchronizeTopics.html
@@ -343,6 +343,15 @@
 										</td>
 									</tr>
 
+									<tr>
+										<td>
+											<font face=verdana size=2><b>Topic Name (filter)</b></font>
+										</td>
+										<td>
+											<input ng-model="getTopics.topicnamesearch">
+										</td>
+									</tr>
+
 
 									<tr>
 										<td>


### PR DESCRIPTION
This merge request will enhance searching topics based on topic names or string containing it.

1. Affected sections. 
   Browse Topics - Added a new text field to enter a topic name or part of it as a filter criteria.
   Sync Topics - Added a new text field to enter a topic name or part of it as a filter criteria.
Page numbers would be displayed accordingly.

With this enhancement, searching topics is much easier instead of going through all the pages and finding it.
