### PR TITLE
Username based acls

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,13 @@
 Release Notes:
 
+- The below changes are part of release 5.0.3
+
+- ACLs can be added based on Usernames (plain text principles). Ex : alice, john
+    On kafka cluster, Producer acls reflects like below for user 'alice' for a topic.
+    (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
+    (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
+
+-----------------------------------------------------------------------------------
 - The below changes are part of release 5.0.2
 
 - Introducing Liquibase for all database migrations

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kafkamgt.uiapi</groupId>
     <artifactId>kafkawize</artifactId>
-    <version>5.0.2</version>
+    <version>5.0.3</version>
     <packaging>jar</packaging>
     <name>Kafkawize</name>
     <description>Kafkawize SelfService - Governance Portal</description>

--- a/src/main/java/com/kafkamgt/uiapi/dao/AclRequests.java
+++ b/src/main/java/com/kafkamgt/uiapi/dao/AclRequests.java
@@ -1,5 +1,6 @@
 package com.kafkamgt.uiapi.dao;
 
+import com.kafkamgt.uiapi.model.AclIPPrincipleType;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -95,6 +96,9 @@ public class AclRequests implements Serializable {
 
     @Column(name = "otherparams")
     private String otherParams;
+
+    @Column(name = "aclipprincipletype")
+    private AclIPPrincipleType aclIpPrincipleType;
 
     @Transient
     private String totalNoPages;

--- a/src/main/java/com/kafkamgt/uiapi/model/AclIPPrincipleType.java
+++ b/src/main/java/com/kafkamgt/uiapi/model/AclIPPrincipleType.java
@@ -1,0 +1,5 @@
+package com.kafkamgt.uiapi.model;
+
+public enum AclIPPrincipleType {
+    IP_ADDRESS, PRINCIPLE, USERNAME
+}

--- a/src/main/java/com/kafkamgt/uiapi/model/AclRequestsModel.java
+++ b/src/main/java/com/kafkamgt/uiapi/model/AclRequestsModel.java
@@ -67,6 +67,8 @@ public class AclRequestsModel implements Serializable {
 
     private String aclType;
 
+    private AclIPPrincipleType aclIpPrincipleType;
+
     // Always TOPIC (for now)
     private String aclResourceType;
 

--- a/src/main/java/com/kafkamgt/uiapi/service/AclControllerService.java
+++ b/src/main/java/com/kafkamgt/uiapi/service/AclControllerService.java
@@ -59,8 +59,6 @@ public class AclControllerService {
             return "{\"result\":\"Not Authorized\"}";
         }
 
-
-
         List<Topic> topics = manageDatabase.getHandleDbRequests().getTopics(aclReq.getTopicname(), tenantId);
         boolean topicFound = false;
         String result;

--- a/src/main/java/com/kafkamgt/uiapi/service/ClusterApiService.java
+++ b/src/main/java/com/kafkamgt/uiapi/service/ClusterApiService.java
@@ -406,6 +406,7 @@ public class ClusterApiService {
             params.add("acl_ip", aclReq.getAcl_ip());
             params.add("acl_ssl", aclReq.getAcl_ssl());
             params.add("transactionalId", aclReq.getTransactionalId());
+            params.add("aclIpPrincipleType", aclReq.getAclIpPrincipleType().name());
 
             if(aclReq.getAclPatternType() != null && aclReq.getAclPatternType().equals("PREFIXED"))
                 params.add("isPrefixAcl", "true");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,9 @@ kafkawize.installation.type=onpremise
 # Possible values "db" or "ad". If SSO config or Active directory is enabled below, this value should be "ad"
 kafkawize.login.authentication.type=db
 
+# Possible values "true" or "false". Enable token authentication for new Angular UI
+kafkawize.login.token.authentication=true
+
 # Database settings
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,9 +19,6 @@ kafkawize.installation.type=onpremise
 # Possible values "db" or "ad". If SSO config or Active directory is enabled below, this value should be "ad"
 kafkawize.login.authentication.type=db
 
-# Possible values "true" or "false". Enable token authentication for new Angular UI
-kafkawize.login.token.authentication=true
-
 # Database settings
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/changelog.yaml

--- a/src/main/resources/db/changelog/changelog.yaml
+++ b/src/main/resources/db/changelog/changelog.yaml
@@ -884,5 +884,14 @@ databaseChangeLog:
             name: tenantid
             type: INT
         tableName: kwusers
-
+- changeSet:
+      id: 27thAug2022 add column to store ip address or principle or username based
+      author: muralibasani
+      changes:
+      - addColumn:
+            tableName: kwaclrequests
+            columns:
+            - column:
+                  name: aclipprincipletype
+                  type: VARCHAR(50)
 

--- a/src/main/resources/static/js/requestAcls.js
+++ b/src/main/resources/static/js/requestAcls.js
@@ -190,17 +190,20 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
                     }
             }
 
+            $scope.selectedAclType="IP_ADDRESS";
             $scope.onSelectAcl = function(selectedAclType){
                     if(selectedAclType =='SSL'){
                         $scope.disable_ssl=false;
                         $scope.disable_ip=true;
                         $scope.acl_ipaddress=[""];
                         $scope.alc_ipaddresslength = $scope.acl_ipaddress.length;
+                        $scope.selectedAclType="PRINCIPLE";  // Principle can be Username or CN certificate string
                     }else{
                         $scope.disable_ssl=true;
                         $scope.disable_ip=false;
                         $scope.acl_ssl=[""];
                         $scope.alc_ssllength = $scope.acl_ssl.length;
+                        $scope.selectedAclType="IP_ADDRESS";
                     }
                 }
 
@@ -417,6 +420,7 @@ app.controller("requestAclsCtrl", function($scope, $http, $location, $window) {
              serviceInput['consumergroup'] = $scope.addAcl.consumergroup;
              serviceInput['aclPatternType'] = aclpatterntypetype;
              serviceInput['transactionalId'] = $scope.addAcl.transactionalId;
+             serviceInput['aclIpPrincipleType'] = $scope.selectedAclType;
 
             $http({
                 method: "POST",

--- a/src/main/resources/templates/browseAcls.html
+++ b/src/main/resources/templates/browseAcls.html
@@ -670,7 +670,7 @@
 																<h6 class="text-primary">IP Address</h6><b>*</b>
 															</div>
 															<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-																<h6 class="text-primary">Principle</h6><b>{{ aclRequest.acl_ssl }}</b>
+																<h6 class="text-primary">Principle / Username</h6><b>{{ aclRequest.acl_ssl }}</b>
 															</div>
 
 															<div class="p-2" style="width:15%">

--- a/src/main/resources/templates/execAcls.html
+++ b/src/main/resources/templates/execAcls.html
@@ -551,7 +551,7 @@
 											<h6 class="text-primary">IP Address</h6><b>*</b>
 										</div>
 										<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-											<h6 class="text-primary">Principle</h6>
+											<h6 class="text-primary">Principle / Username</h6>
 											<table>
 												<tr ng-repeat="onessl in aclRequest.acl_ssl">
 													<td>

--- a/src/main/resources/templates/myAclRequests.html
+++ b/src/main/resources/templates/myAclRequests.html
@@ -526,7 +526,7 @@
 										<h6 class="text-primary">IP Address</h6><b>*</b>
 									</div>
 									<div ng-show="aclRequest.acl_ssl != null" class="p-2 border-right" style="width:30%">
-										<h6 class="text-primary">Principle</h6>
+										<h6 class="text-primary">Principle / Username</h6>
 										<table>
 											<tr ng-repeat="onessl in aclRequest.acl_ssl">
 												<td>

--- a/src/main/resources/templates/requestAcls.html
+++ b/src/main/resources/templates/requestAcls.html
@@ -555,14 +555,14 @@
 									<div class="row">
 										<div class="col-md-12">
 											<div class="form-group">
-												<label class="control-label">Acl IP or SSL based</label>
+												<label class="control-label">Acl IP or Principle Or Username based</label>
 												<div class="demo-radio-button" ng-init="addAcl.acl_ip_ssl='IP'">
 													<input class="radio-col-orange" ng-change="onSelectAcl('IP')" ng-model="addAcl.acl_ip_ssl" name="group1"
 														   type="radio" id="radio_1" value="IP" checked />
 													<label for="radio_1">IP Address</label>
 													<input class="radio-col-orange" ng-change="onSelectAcl('SSL')" ng-model="addAcl.acl_ip_ssl"
 														   name="group1" type="radio" id="radio_2" value="SSL" />
-													<label for="radio_2">Principle</label>
+													<label for="radio_2">Principle / Username</label>
 												</div>
 
 											</div>
@@ -601,7 +601,7 @@
 
 										<div class="col-md-6">
 											<div class="form-group">
-												<label>Principle</label>
+												<label>Principle / Username</label>
 												<table>
 													<tr valign="top" ng-repeat="onessl in acl_ssl track by $index">
 														<td width="95%">
@@ -623,6 +623,8 @@
 
 
 												<small class="form-control-feedback"> Ex: CN=myhost,OU=IS,OU=OU,OU=Services,O=Org</small>
+												<br>
+												<small class="form-control-feedback"> Ex: alice</small>
 											</div>
 										</div>
 										<!--/span-->


### PR DESCRIPTION
- The below changes are part of release 5.0.3

- ACLs can be added based on Usernames (plain text principles). Ex : alice, john
    On kafka cluster, Producer acls reflects like below for user 'alice' for a topic.
    (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)
    (principal=User:alice, host=*, operation=WRITE, permissionType=ALLOW)